### PR TITLE
Vivado 22.1 repackage and asynchronous registers

### DIFF
--- a/component.xml
+++ b/component.xml
@@ -347,11 +347,13 @@
   <spirit:memoryMaps>
     <spirit:memoryMap>
       <spirit:name>s00_axi</spirit:name>
+      <spirit:displayName>s00_axi</spirit:displayName>
       <spirit:addressBlock>
         <spirit:name>reg0</spirit:name>
-        <spirit:baseAddress spirit:format="bitString" spirit:resolve="user" spirit:bitStringLength="32">0</spirit:baseAddress>
-        <spirit:range spirit:format="long" spirit:resolve="user" spirit:minimum="4096" spirit:rangeType="long">256</spirit:range>
-        <spirit:width spirit:format="long" spirit:resolve="user">32</spirit:width>
+        <spirit:displayName>reg0</spirit:displayName>
+        <spirit:baseAddress spirit:format="bitString" spirit:bitStringLength="1">0x0</spirit:baseAddress>
+        <spirit:range spirit:format="bitString" spirit:bitStringLength="13" spirit:minimum="4096" spirit:rangeType="long">0x1000</spirit:range>
+        <spirit:width spirit:format="long">32</spirit:width>
         <spirit:usage>register</spirit:usage>
       </spirit:addressBlock>
     </spirit:memoryMap>
@@ -362,7 +364,7 @@
         <spirit:name>xilinx_anylanguagesynthesis</spirit:name>
         <spirit:displayName>Synthesis</spirit:displayName>
         <spirit:envIdentifier>:vivado.xilinx.com:synthesis</spirit:envIdentifier>
-        <spirit:language>VHDL</spirit:language>
+        <spirit:language>VHDL-2008</spirit:language>
         <spirit:modelName>clock_measure_vivado_wrp</spirit:modelName>
         <spirit:fileSetRef>
           <spirit:localName>xilinx_anylanguagesynthesis_view_fileset</spirit:localName>
@@ -370,7 +372,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>3f51eb2e</spirit:value>
+            <spirit:value>5f7a3a88</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -378,7 +380,7 @@
         <spirit:name>xilinx_anylanguagebehavioralsimulation</spirit:name>
         <spirit:displayName>Simulation</spirit:displayName>
         <spirit:envIdentifier>:vivado.xilinx.com:simulation</spirit:envIdentifier>
-        <spirit:language>VHDL</spirit:language>
+        <spirit:language>VHDL-2008</spirit:language>
         <spirit:modelName>clock_measure_vivado_wrp</spirit:modelName>
         <spirit:fileSetRef>
           <spirit:localName>xilinx_anylanguagebehavioralsimulation_view_fileset</spirit:localName>
@@ -386,7 +388,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>3f51eb2e</spirit:value>
+            <spirit:value>5f7a3a88</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -400,7 +402,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>9bda48fc</spirit:value>
+            <spirit:value>6aa5372c</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -442,7 +444,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>54d2b22a</spirit:value>
+            <spirit:value>d7a037cc</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -1132,38 +1134,38 @@
       <spirit:name>xilinx_anylanguagesynthesis_view_fileset</spirit:name>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_array_pkg.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_math_pkg.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_logic_pkg.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_pl_stage.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_axi_slave_ipif.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>hdl/single_clock_measurement.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>hdl/clock_measure_vivado_wrp.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_49fe8024</spirit:userFileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_8aeede91</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
     </spirit:fileSet>
@@ -1171,37 +1173,37 @@
       <spirit:name>xilinx_anylanguagebehavioralsimulation_view_fileset</spirit:name>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_array_pkg.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_math_pkg.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_logic_pkg.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_pl_stage.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>../../VHDL/psi_common/hdl/psi_common_axi_slave_ipif.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>hdl/single_clock_measurement.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
         <spirit:name>hdl/clock_measure_vivado_wrp.vhd</spirit:name>
-        <spirit:fileType>vhdlSource</spirit:fileType>
+        <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
     </spirit:fileSet>
@@ -1210,7 +1212,7 @@
       <spirit:file>
         <spirit:name>xgui/clock_measure_v1_4.tcl</spirit:name>
         <spirit:fileType>tclSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_9bda48fc</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_6aa5372c</spirit:userFileType>
         <spirit:userFileType>XGUI_VERSION_2</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
@@ -1282,48 +1284,42 @@
   <spirit:vendorExtensions>
     <xilinx:coreExtensions>
       <xilinx:supportedFamilies>
+        <xilinx:family xilinx:lifeCycle="Production">spartan7</xilinx:family>
         <xilinx:family xilinx:lifeCycle="Production">artix7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">virtex7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">qvirtex7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">kintex7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">kintex7l</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">qkintex7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">qkintex7l</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">artix7l</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">aartix7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">qartix7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">zynq</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">qzynq</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">azynq</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">spartan7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">aspartan7</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">virtexu</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">virtexuplus</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">kintexuplus</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">zynquplus</xilinx:family>
-        <xilinx:family xilinx:lifeCycle="Beta">kintexu</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">artix7l</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">kintex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">kintex7l</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">kintexu</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">kintexuplus</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">virtex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">virtexu</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">virtexuplus</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">zynq</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">zynquplus</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">aspartan7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">aartix7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">azynq</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qartix7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qkintex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qkintex7l</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qvirtex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qzynq</xilinx:family>
       </xilinx:supportedFamilies>
       <xilinx:taxonomies>
-        <xilinx:taxonomy>/UserIP</xilinx:taxonomy>
+        <xilinx:taxonomy>&quot;/UserIP&quot;</xilinx:taxonomy>
       </xilinx:taxonomies>
-      <xilinx:displayName>clock_measure_1_4</xilinx:displayName>
+      <xilinx:displayName>clock_measure</xilinx:displayName>
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
-      <xilinx:vendorDisplayName>Paul Scherrer Institut</xilinx:vendorDisplayName>
+      <xilinx:vendorDisplayName>Paul Scherrer Institute</xilinx:vendorDisplayName>
       <xilinx:vendorURL>http://www.psi.ch</xilinx:vendorURL>
-      <xilinx:coreRevision>1564729821</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2019-08-02T07:11:04Z</xilinx:coreCreationDateTime>
-      <xilinx:tags>
-        <xilinx:tag xilinx:name="psi.ch:user:clock_measure_vivado_wrp:1.0_ARCHIVE_LOCATION">d:/gfa/Libraries/Firmware/VivadoIp/vivadoIP_clock_measure</xilinx:tag>
-        <xilinx:tag xilinx:name="psi.ch:user:clock_measure:1.0_ARCHIVE_LOCATION">d:/gfa/Libraries/Firmware/VivadoIp/vivadoIP_clock_measure</xilinx:tag>
-        <xilinx:tag xilinx:name="psi.ch:PSI:clock_measure:1.0_ARCHIVE_LOCATION">d:/gfa/Libraries/Firmware/VivadoIp/vivadoIP_clock_measure</xilinx:tag>
-        <xilinx:tag xilinx:name="psi.ch:PSI:clock_measure:1.4_ARCHIVE_LOCATION">d:/gfa/Libraries/Firmware/VivadoIp/vivadoIP_clock_measure</xilinx:tag>
-      </xilinx:tags>
+      <xilinx:coreRevision>1688389429</xilinx:coreRevision>
+      <xilinx:coreCreationDateTime>2023-07-03T13:05:07Z</xilinx:coreCreationDateTime>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
-      <xilinx:xilinxVersion>2018.1</xilinx:xilinxVersion>
+      <xilinx:xilinxVersion>2022.1</xilinx:xilinxVersion>
       <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="51cb901c"/>
-      <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="a9f63fc9"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="2f37765d"/>
+      <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="2b8fc426"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="9adc3338"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="bff3631f"/>
       <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="81bd4494"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="fd76fb0b"/>

--- a/component.xml
+++ b/component.xml
@@ -372,7 +372,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>5f7a3a88</spirit:value>
+            <spirit:value>bd5971a4</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -388,7 +388,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>5f7a3a88</spirit:value>
+            <spirit:value>0661c965</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -1163,9 +1163,13 @@
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
       <spirit:file>
+        <spirit:name>constraints/single_clock_measurement_timing.xdc</spirit:name>
+        <spirit:userFileType>xdc</spirit:userFileType>
+      </spirit:file>
+      <spirit:file>
         <spirit:name>hdl/clock_measure_vivado_wrp.vhd</spirit:name>
         <spirit:userFileType>vhdlSource-2008</spirit:userFileType>
-        <spirit:userFileType>CHECKSUM_8aeede91</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_bfd7f3d5</spirit:userFileType>
         <spirit:logicalName>clock_measure_1_4</spirit:logicalName>
       </spirit:file>
     </spirit:fileSet>
@@ -1312,14 +1316,14 @@
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
       <xilinx:vendorDisplayName>Paul Scherrer Institute</xilinx:vendorDisplayName>
       <xilinx:vendorURL>http://www.psi.ch</xilinx:vendorURL>
-      <xilinx:coreRevision>1688389429</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2023-07-03T13:05:07Z</xilinx:coreCreationDateTime>
+      <xilinx:coreRevision>1688741449</xilinx:coreRevision>
+      <xilinx:coreCreationDateTime>2023-07-07T14:52:10Z</xilinx:coreCreationDateTime>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2022.1</xilinx:xilinxVersion>
       <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="51cb901c"/>
       <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="2b8fc426"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="9adc3338"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="25143f13"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="bff3631f"/>
       <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="81bd4494"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="fd76fb0b"/>

--- a/constraints/single_clock_measurement_timing.xdc
+++ b/constraints/single_clock_measurement_timing.xdc
@@ -1,0 +1,5 @@
+
+
+#false path constraint for asynchronous registers
+set_false_path -to [get_cells -hierarchical -filter {NAME =~ *async_fd_inst && IS_SEQUENTIAL}]
+

--- a/drivers/clock_measure/data/clock_measure.tcl
+++ b/drivers/clock_measure/data/clock_measure.tcl
@@ -1,5 +1,5 @@
 
 
 proc generate {drv_handle} {
-	xdefine_include_file $drv_handle "xparameters.h" clock_measure "NUM_INSTANCES" "DEVICE_ID"  "C_BASEADDR" "C_HIGHADDR"
+	xdefine_include_file $drv_handle "xparameters.h" clock_measure "NUM_INSTANCES" "DEVICE_ID"  "C_BASEADDR" "C_HIGHADDR" 
 }

--- a/drivers/clock_measure/src/Makefile
+++ b/drivers/clock_measure/src/Makefile
@@ -1,4 +1,3 @@
-DRIVER_LIB_VERSION = 1.0
 COMPILER=
 ARCHIVER=
 CP=cp
@@ -6,35 +5,24 @@ COMPILER_FLAGS=
 EXTRA_COMPILER_FLAGS=
 LIB=libxil.a
 
-CC_FLAGS = $(COMPILER_FLAGS)
-ECC_FLAGS = $(EXTRA_COMPILER_FLAGS)
+RELEASEDIR=../../../lib
+INCLUDEDIR=../../../include
+INCLUDES=-I./. -I${INCLUDEDIR}
 
-RELEASEDIR=../../../lib/
-INCLUDEDIR=../../../include/
-INCLUDES=-I./. -I$(INCLUDEDIR)
+INCLUDEFILES=*.h
+LIBSOURCES=*.c
+OBJECTS = $(addsuffix .o, $(basename $(wildcard *.c)))
+ASSEMBLY_OBJECTS = $(addsuffix .o, $(basename $(wildcard *.S)))
 
-SRCFILES:=$(wildcard *.c)
-
-OBJECTS = $(addprefix $(RELEASEDIR), $(addsuffix .o, $(basename $(wildcard *.c))))
-
-libs: $(OBJECTS)
+libs:
 	echo "Compiling clock_measure..."
+	$(COMPILER) $(COMPILER_FLAGS) $(EXTRA_COMPILER_FLAGS) $(INCLUDES) $(LIBSOURCES)
+	$(ARCHIVER) -r ${RELEASEDIR}/${LIB} ${OBJECTS} ${ASSEMBLY_OBJECTS}
+	make clean
 
-DEPFILES := $(SRCFILES:%.c=$(RELEASEDIR)%.d)
-
-include $(wildcard $(DEPFILES))
-
-include $(wildcard ../../../../dep.mk)
-
-$(RELEASEDIR)%.o: %.c
-	${COMPILER} $(CC_FLAGS) $(ECC_FLAGS) $(INCLUDES) $(DEPENDENCY_FLAGS) $< -o $@
-
-.PHONY: include
-include: $(addprefix $(INCLUDEDIR),$(wildcard *.h))
-
-$(INCLUDEDIR)%.h: %.h
-	$(CP) $< $@
+include:
+	${CP} $(INCLUDEFILES) $(INCLUDEDIR)
 
 clean:
-	rm -rf ${OBJECTS}
-	rm -rf $(DEPFILES)
+	-@rm -rf ${OBJECTS} ${ASSEMBLY_OBJECTS}
+

--- a/hdl/clock_measure_vivado_wrp.vhd
+++ b/hdl/clock_measure_vivado_wrp.vhd
@@ -116,7 +116,7 @@ begin
    (
       -- Users parameters
       num_reg_g                    => USER_SLV_NUM_REG,
-	  use_mem_g                    => false,
+      use_mem_g                    => false,
       -- Parameters of Axi Slave Bus Interface
       axi_id_width_g                => C_S00_AXI_ID_WIDTH,
       axi_addr_width_g              => 8
@@ -189,7 +189,7 @@ begin
 			)
 			port map (
 				ClkMaster		=> s00_axi_aclk,
-				Rst				=> AxiRst,
+				Rst			=> AxiRst,
 				FrequencyHz		=> reg_rdata(idx),
 				ClkTest			=> Clocks(idx)
 			);

--- a/hdl/single_clock_measurement.vhd
+++ b/hdl/single_clock_measurement.vhd
@@ -4,12 +4,21 @@
 --  Authors: Oliver Bruendler
 ------------------------------------------------------------------------------
 
+
+--Add next line to constraints file:
+--set_false_path -to [get_cells -hierarchical -filter {NAME =~ *async_fd_inst && IS_SEQUENTIAL}]
+
+
 -------------------------------------------------------------------------------
 -- Libraries
 -------------------------------------------------------------------------------
 library ieee;
 	use ieee.std_logic_1164.all;
 	use ieee.numeric_std.all;
+
+library unisim;
+        use unisim.vcomponents.all;
+
 
 -------------------------------------------------------------------------------
 -- Entity
@@ -24,7 +33,7 @@ entity single_clock_measurement is
 		-- Control Signals
 		----------------------------------------
 		ClkMaster		: in	std_logic;
-		Rst				: in	std_logic;
+		Rst			: in	std_logic;
 		
 		----------------------------------------
 		-- Test
@@ -48,18 +57,35 @@ architecture rtl of single_clock_measurement is
 	----------------------------------------
 	signal Cntr1Hz_M 			: integer range 0 to MasterFrequency_g-1;
 	signal Toggle1Hz_M			: std_logic;
-	signal ResultToggleSync_M	: std_logic_vector(2 downto 0);
-	signal AwaitResult_M		: std_logic;
-	
+	signal ResultToggle_M   	        : std_logic;
+	signal ResultToggleSync_M	        : std_logic_vector(2 downto 0);
+	signal AwaitResult_M		        : std_logic;
+	signal FrequencyHz_M	  	        : std_logic_vector(31 downto 0);
+
+        
 	----------------------------------------
 	-- Signals Test Clock
 	----------------------------------------	
-	signal Toggle1HzSync_T		: std_logic_vector(2 downto 0);
+	signal Rst_T		                : std_logic;
 	signal CntrTest_T			: integer range 0 to MaxMeasFrequency_g;
 	signal Result_T				: integer range 0 to MaxMeasFrequency_g;
-	signal ResultToggle_T		: std_logic;	
+	signal ResultToggle_T		        : std_logic;	
+	signal Toggle1Hz_T			: std_logic;
+	signal Toggle1HzSync_T		        : std_logic_vector(2 downto 0);
+	signal FrequencyHz_T	  	        : std_logic_vector(31 downto 0);
 
+        
+	---------------------------------------------------------------------------
+	-- Asynchonous flip-flops
+	---------------------------------------------------------------------------
+        attribute ASYNC_REG                                   : string;
+        attribute ASYNC_REG of Rst_T_async_fd_inst            : label is "true";
+        attribute ASYNC_REG of Toggle1Hz_T_async_fd_inst      : label is "true";
+        attribute ASYNC_REG of ResultToggle_M_async_fd_inst   : label is "true";
+
+        
 begin
+
 
 	---------------------------------------------------------------------------
 	-- Reset Generation and Result Latching(Master Clock)
@@ -68,7 +94,7 @@ begin
 	begin
 		if rising_edge(ClkMaster) then
 			if Rst = '1' then
-				Cntr1Hz_M 			<= MasterFrequency_g-1;
+				Cntr1Hz_M 		<= MasterFrequency_g-1;
 				Toggle1Hz_M 		<= '0';
 				AwaitResult_M 		<= '0';
 				FrequencyHz 		<= (others => '0');
@@ -76,7 +102,7 @@ begin
 			else
 				-- Request new result
 				if Cntr1Hz_M = 0 then
-					Cntr1Hz_M 		<= MasterFrequency_g-1;
+					Cntr1Hz_M 	<= MasterFrequency_g-1;
 					Toggle1Hz_M 	<= not Toggle1Hz_M;
 					AwaitResult_M 	<= '1';
 					if AwaitResult_M = '1' then
@@ -87,41 +113,75 @@ begin
 				end if;
 				
 				-- Latch new result
-				ResultToggleSync_M <= ResultToggleSync_M(1 downto 0) & ResultToggle_T;
+				ResultToggleSync_M <= ResultToggleSync_M(1 downto 0) & ResultToggle_M;
 				if ResultToggleSync_M(2) /= ResultToggleSync_M(1) then
-					FrequencyHz <= std_logic_vector(to_unsigned(Result_T, 32));
-					AwaitResult_M 	<= '0';
+                                  FrequencyHz   <= FrequencyHz_M;
+                                  AwaitResult_M <= '0';
 				end if;		
 			end if;
 		end if;
 	end process;
 
+
+        
 	---------------------------------------------------------------------------
 	-- Edge Counter (Test Clock)
 	---------------------------------------------------------------------------
 	p_meas : process(ClkTest)
 	begin
 		if rising_edge(ClkTest) then
-			if Rst = '1' then
+			if Rst_T = '1' then
 				Toggle1HzSync_T <= (others => '0');
 				ResultToggle_T 	<= '0';
-				Result_T 		<= 0;
+				Result_T 	<= 0;
 			else
-				Toggle1HzSync_T <= Toggle1HzSync_T(1 downto 0) & Toggle1Hz_M;
+				Toggle1HzSync_T <= Toggle1HzSync_T(1 downto 0) & Toggle1Hz_T;
 				
 				-- On every toggle, reset counter and output result
 				if Toggle1HzSync_T(2) /= Toggle1HzSync_T(1) then	
-					CntrTest_T 		<= 1; --the first edge implicitly arrived
-					Result_T 		<= CntrTest_T;
+					CntrTest_T 	<= 1; --the first edge implicitly arrived
+					Result_T 	<= CntrTest_T;
 					ResultToggle_T 	<= not ResultToggle_T;
 				-- Otherwise count (prevent overflows!)
 				elsif CntrTest_T /= MaxMeasFrequency_g then
-					CntrTest_T 		<= CntrTest_T + 1;
+					CntrTest_T      <= CntrTest_T + 1;
 				end if;
 			end if;
 		end if;
 	end process;
-	
+
+
+        
+	---------------------------------------------------------------------------
+	-- Asynchonous flip-flops
+	---------------------------------------------------------------------------
+        Rst_T_async_fd_inst : fd
+        port map(c => ClkTest,
+                 d => Rst,
+                 q => Rst_T);
+        
+        Toggle1Hz_T_async_fd_inst : fd
+        port map(c => ClkTest,
+                 d => Toggle1Hz_M,
+                 q => Toggle1Hz_T);
+
+        ResultToggle_M_async_fd_inst : fd
+        port map(c => ClkMaster,
+                 d => ResultToggle_T,
+                 q => ResultToggle_M);
+
+
+        FrequencyHz_T <= std_logic_vector(to_unsigned(Result_T, 32));
+        frequency_asyn_fds : for i in 0 to 31 generate
+          attribute ASYNC_REG of FrequencyHz_async_fd_inst   : label is "true";
+        begin 
+          FrequencyHz_async_fd_inst : fd
+            port map(c => ClkMaster,
+                     d => FrequencyHz_T(i),
+                     q => FrequencyHz_M(i));
+        end generate;
+                                    
+
 
 end;
 

--- a/scripts/package.tcl
+++ b/scripts/package.tcl
@@ -32,6 +32,7 @@ set_datasheet_relative "../doc/$IP_NAME.pdf"
 add_sources_relative { \
 	../hdl/single_clock_measurement.vhd \
 	../hdl/clock_measure_vivado_wrp.vhd \
+	../constraints/single_clock_measurement_timing.xdc \
 }
 
 #PSI Common


### PR DESCRIPTION
Please merge in the modifications:

1. Repackaged for Vivado 22.1
2. Implemented asynchronous registers and corresponding false_path constraint for all signals that cross clock domains.